### PR TITLE
Reduce image size by aggregating RUN commands

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update \
     && make USE_PGXS=1 install \
 
     # cleanup
+    && cd /tmp \
     && rm -rf /tmp/* \
     && apt-get purge -y --auto-remove \
         wget \


### PR DESCRIPTION
## Context

The current image size of `scalardb-analytics-postgresql` is 1.47GB, which could not be accepted as a product to users. 

## What are changed

Multiple `RUN` commands are now aggregated into a single `RUN` in the Dockerfile to build `scalardb-analytics-postgresql`.

The final image size has been reduced from 1.47GB to 723 MB.

## Other considerations

Caching becomes ineffective during the image build since no intermediate layer is created.