### PR TITLE
Fix NullPointerException in ReScanForeignScan

### DIFF
--- a/scalardb_fdw/scalardb_fdw.c
+++ b/scalardb_fdw/scalardb_fdw.c
@@ -377,7 +377,7 @@ static void scalardbReScanForeignScan(ForeignScanState *node)
 	ereport(DEBUG3, errmsg("entering function %s", __func__));
 
 	fdw_state = (ScalarDbFdwScanState *)node->fdw_state;
-	if (!fdw_state->scanner)
+	if (fdw_state->scanner)
 		scalardb_scanner_close(fdw_state->scanner);
 
 	fdw_state->scanner = scalardb_scan_all(fdw_state->options.namespace,


### PR DESCRIPTION
## Context

When we run complex queries that read data via `scalardb_fdw`, `NullPointerExceptions` sometimes occur. 

Through the investigation, we found that this error occurs only when the `ReScanForeignScan`, and the non-null check in that callback function is the opposite of what was intended.

## What are changed?

Corrected the non-null check.

## Other considerations.

None.