### PR TITLE
Follow symbolic link when searching JAVA_HOME in Makefile

### DIFF
--- a/scalardb_fdw/Makefile
+++ b/scalardb_fdw/Makefile
@@ -18,7 +18,7 @@ OS = $(shell uname | tr '[:upper:]' '[:lower:]')
 
 PG_CPPFLAGS = -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(OS) -D'SCALARDB_JAR_PATH=$(scalardb_jar_path)'
 
-libjvm_path = $(shell find $(JAVA_HOME) -name libjvm\.*)
+libjvm_path = $(shell find -L $(JAVA_HOME) -name libjvm\.*)
 
 SHLIB_LINK+=-L$(dir $(libjvm_path)) -ljvm
 


### PR DESCRIPTION
## Description

I failed to build `scalardb_fdw` due to the following error while JAVA_HOME was exported.

```
ld: warning: directory not found for option '-L-ljvm'                                                                                                                                
Undefined symbols for architecture arm64:                                                                                                                                            
  "_JNI_CreateJavaVM", referenced from:                                                                                                                                              
      _scalardb_initialize in scalardb.o                                                                                                                                             
  "_JNI_GetCreatedJavaVMs", referenced from:                                                                                                                                         
      _scalardb_initialize in scalardb.o                                                                                                                                             
ld: symbol(s) not found for architecture arm64
```

In my local environment, I use `jenv` to manage various JDKs as follows
```
$ ls -l ~/.jenv/versions/
total 0
lrwxr-xr-x  1 mitsunorikomatsu  staff  88 Nov  2  2022 1.8 -> /Users/mitsunorikomatsu/Library/Java/JavaVirtualMachines/temurin-1.8.0_345/Contents/Home
lrwxr-xr-x  1 mitsunorikomatsu  staff  88 Nov  2  2022 1.8.0.345 -> /Users/mitsunorikomatsu/Library/Java/JavaVirtualMachines/temurin-1.8.0_345/Contents/Home
lrwxr-xr-x  1 mitsunorikomatsu  staff  28 Oct  6  2022 11.0 -> /opt/homebrew/opt/openjdk@11
lrwxr-xr-x  1 mitsunorikomatsu  staff  28 Oct  6  2022 11.0.16.1 -> /opt/homebrew/opt/openjdk@11
 :
```

And I sometimes set JAVA_HOME to `~/.jenv/versions/11.0/`, although probably I should've set it to `/opt/homebrew/opt/openjdk@11` instead.

In this case, the Makefile can't find `libjvm.(so|dylib)` since `find` command doesn't follow symlinks by default.

## Related Issue(s)

None

## Changes Made

This PR adds `-L` option to `$(shell find $(JAVA_HOME) -name libjvm\.*)` in the Makefile to search JAVA_HOME through a symbolic link

## Screenshots (if applicable)

None

## Testing Done

With this change, `make install` succeeded.

```
$ make install                                       
/Users/mitsunorikomatsu/.jenv/versions/11.0//libexec/openjdk.jdk/Contents/Home/lib/server/libjvm.dylib
-L/Users/mitsunorikomatsu/.jenv/versions/11.0//libexec/openjdk.jdk/Contents/Home/lib/server/ -ljvm
clang -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Werror=unguarded-availability-new -Wendif-labels -Wmissing-format-attribute -Wcast-functi
on-type -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -Wno-deprecated-non-prototype -O2  -bundle -multiply_defi
ned suppress -o scalardb_fdw.so scalardb_fdw.o option.o scalardb.o condition.o column_metadata.o pgport.o cost.o pathkeys.o -L/opt/homebrew/lib/postgresql@14  -isysroot /Library/Dev
eloper/CommandLineTools/SDKs/MacOSX13.sdk -L/opt/homebrew/opt/openssl@1.1/lib -L/opt/homebrew/opt/readline/lib -L/opt/homebrew/Cellar/lz4/1.9.4/lib  -Wl,-dead_strip_dylibs   -L/User
s/mitsunorikomatsu/.jenv/versions/11.0//libexec/openjdk.jdk/Contents/Home/lib/server/ -ljvm -bundle_loader /opt/homebrew/Cellar/postgresql@14/14.8_1/bin/postgres
./gradlew scalardb-utils:shadowJar                                                                                                                                                   
Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use --status for details                                                        
                                                                                                                                                                                     
BUILD SUCCESSFUL in 9s                                                                                                                                                               
2 actionable tasks: 2 executed                                                                                                                                                       
/bin/sh /opt/homebrew/lib/postgresql@14/pgxs/src/makefiles/../../config/install-sh -c -d '/opt/homebrew/lib/postgresql@14'                                            
/bin/sh /opt/homebrew/lib/postgresql@14/pgxs/src/makefiles/../../config/install-sh -c -d '/opt/homebrew/share/postgresql@14/extension'                            
/bin/sh /opt/homebrew/lib/postgresql@14/pgxs/src/makefiles/../../config/install-sh -c -d '/opt/homebrew/share/postgresql@14/extension'                    
/usr/bin/install -c -m 755  scalardb_fdw.so '/opt/homebrew/lib/postgresql@14/scalardb_fdw.so'
/usr/bin/install -c -m 644 .//scalardb_fdw.control '/opt/homebrew/share/postgresql@14/extension/'
/usr/bin/install -c -m 644 .//scalardb_fdw--1.0.sql scalardb-utils/build/libs/scalardb-3.9.0-all.jar '/opt/homebrew/share/postgresql@14/extension/'
```

## Checklist

- [ ] Unit tests have been added for the changes. (if applicable).
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] Any remaining open issues linked to this PR are documented (JIRA,GitHub).

## Additional Notes (optional)

None