### PR TITLE
Use the forked version of jdbc_fdw

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/scalar-labs/jdk8-postgres15:1.0.3
 
-ENV JDBC_FDW_VERSION=0.3.0 \
+ENV JDBC_FDW_VERSION=0.3.0-forked \
     CASSANDRA_CPP_DRIVER_VERSION=2.16.2 \
     CASSANDRA_FDW_VERSION=ae5e8145e341f50c150a05d464a9fa4a5eb91179
 
@@ -22,7 +22,7 @@ RUN apt-get update \
     # jdbc_fdw
     && cd /tmp \
     && ln -s $(find /usr/local/openjdk-8 -name libjvm.so) /usr/lib \
-    && wget -q https://github.com/pgspider/jdbc_fdw/archive/refs/tags/v${JDBC_FDW_VERSION}.tar.gz \
+    && wget -q https://github.com/scalar-labs/jdbc_fdw/archive/refs/tags/v${JDBC_FDW_VERSION}.tar.gz \
     && tar zxf v${JDBC_FDW_VERSION}.tar.gz \
     && cd jdbc_fdw-${JDBC_FDW_VERSION} \
     && make USE_PGXS=1 install \


### PR DESCRIPTION
## Description

Currently, we use the original version of `jdbc_fdw` to build a docker image. It contains a JVM creation issue due to the limitation of JNI.

This PR changes this to use our forked version of `jdbc_fdw`, where the issue has been fixed by reusing the existing JVM if it exists.


## Related Issue(s)

Close #31 

## Changes Made

This modifies `Dockerfile` to refer to the forked version of `jfdc_fdw`.

## Screenshots (if applicable)

N/A

## Testing Done

I've confirmed that we are able to build an image without an error.

## Checklist

- [ ] Unit tests have been added for the changes. (if applicable).
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] Any remaining open issues linked to this PR are documented (JIRA,GitHub).

## Additional Notes (optional)

None