### PR TITLE
Fix the detached JNI Env issue

### DIFF
--- a/scalardb_fdw/scalardb.c
+++ b/scalardb_fdw/scalardb.c
@@ -181,6 +181,9 @@ void scalardb_initialize(ScalarDbFdwOptions *opts)
 	if (already_initialized == true) {
 		ereport(DEBUG3,
 			errmsg("scalardb has already been initialized"));
+		/* Check if JNI Env is available. This is required because other extensions, like jdbc_fdw,
+		 * may detaches JNI Env from the thread. We need to re-attach it, then. */
+		get_jni_env();
 		return;
 	}
 


### PR DESCRIPTION
## Description

`scalardb_fdw` creates a JVM and attaches a corresponding JNI Env only once [here](https://github.com/scalar-labs/scalardb-analytics-postgresql/blob/3d3d46d00d689e29fb1b24e352b70d488072900b/scalardb_fdw/scalardb.c#L174-L201), and re-use the created JVM and JNI Env until the connection is closed. However, another extension may detach the JNI Env outside of this extension. This causes an error due to a reference to a detached JNI Env.

## Related Issue(s)

None

## Changes Made

Even when the JVM has been initialized, we check the JVM Env is available. If it is detached from the thread, it will re-attach it.

## Screenshots (if applicable)

N/A

## Testing Done

The error can be replicated with the following steps:

1. Read a table backed by `scalardb_fdw`
2. Read a table backed by `jdbc_fdw`
3. Re-read the table of the step 1.

The JNI Env created in step 1. will be detached in step 2. So, in step 3., `scalardb_fdw` cannot refer to the attached JNI Env, so an error occurs.

I confirmed the same error does not occur after the change of this PR is applied.

## Checklist

- [ ] Unit tests have been added for the changes. (if applicable).
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] Any remaining open issues linked to this PR are documented (JIRA,GitHub).

## Additional Notes (optional)

None