### PR TITLE
Bump up version to 3.10.1

### DIFF
--- a/schema-importer/app/build.gradle.kts
+++ b/schema-importer/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 group = "com.scalar-labs"
 
-project.version = "3.10.0"
+project.version = "3.10.1"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Description

This PR bumps up the version to 3.10.1

## Related Issue(s)

This version mainly contains the bug fixes. i.e. #32 #34 .

## Changes Made

This PR itself bumps up the gradle project version. After this PR is merged, I'll add a git tag to the merge commit and release the images of `3.10.1`.

## Testing Done

None

## Checklist

- [ ] Unit tests have been added for the changes. (if applicable).
- [ ] The documentation has been updated to reflect the changes (if applicable).
- [ ] Any remaining open issues linked to this PR are documented (JIRA,GitHub).

## Additional Notes (optional)

None