### PR TITLE
fix(schema-importer): fix warning due to Netty's native transport library

### DIFF
--- a/schema-importer/app/build.gradle.kts
+++ b/schema-importer/app/build.gradle.kts
@@ -26,6 +26,14 @@ dependencies {
     implementation("org.slf4j:slf4j-api:2.0.7")
     implementation("org.slf4j:slf4j-simple:2.0.7")
 
+    // These dependencies are added as tentative solution for the warnings caused by missing of
+    // Netty's native transport library.
+    // Once this issue is addressed in the ScalarDB core, these will be removed.
+    implementation("io.netty:netty-transport-native-epoll:4.1.99.Final:linux-x86_64")
+    implementation("io.netty:netty-transport-native-epoll:4.1.99.Final:linux-aarch_64")
+    implementation("io.netty:netty-transport-native-kqueue:4.1.99.Final:osx-x86_64")
+    implementation("io.netty:netty-transport-native-kqueue:4.1.99.Final:osx-aarch_64")
+
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.9.2")
     testImplementation("io.mockk:mockk:1.13.5")


### PR DESCRIPTION
## Description

When we run a container of the schema-importer image of M1 Mac, we get a warnings as follows:

```
[main] WARN com.datastax.driver.core.NettyUtil - Found Netty's native epoll transport in the classpath, but epoll is not available. Using NIO instead.
java.lang.UnsatisfiedLinkError: could not load a native library: netty_transport_native_epoll_aarch_64
	at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:239)
```

This is due to the missing of the Netty's epoll library for the Arm architecture. To solve this, this commit adds dependencies on amd64 and arm64 explicitly.

## Related issues and/or PRs

Please refer to the Slack thread for more details:
https://scalar-labs.slack.com/archives/CDSFWGSTZ/p1696562747354819

## Changes made

Add explicit dependencies on `netty-transport-native-epoll` and `netty-transport-native-kqueue` for amd64 and arm64.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

Fix warning regarding Netty's native epoll transport 
