### PR TITLE
Bump up the project version to 3.10.2

### DIFF
--- a/schema-importer/app/build.gradle.kts
+++ b/schema-importer/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 group = "com.scalar-labs"
 
-project.version = "3.10.1"
+project.version = "3.10.2"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Description

This PR bumps up the project version to 3.10.2. After this PR is merged, v3.10.2 will be released.

## Related issues and/or PRs

None

## Changes made

Set the gradle project version to 3.10.2

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This release includes:

- #38 
- #39
## Release notes

N/A