### PR TITLE
DLT-14713 Revise Getting Started documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,12 +17,23 @@ PostgreSQL runs as a service, accepting queries from users to process. FDW exten
 First, you need one or more ScalarDB databases to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have your own ScalarDB database, you can skip this section and use your database instead. If you use the [scalardb-samples/scalardb-analytics-postgresql-sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-analytics-postgresql-sample) project, you can set up a sample database by running the following command in the project directory.
 
 ```shell
-$ docker compose run --rm sql-cli --config /etc/scalardb.properties --file /etc/sample_data.sql
+$ docker compose run --rm schema-loader \
+  -c /etc/scalardb.properties \
+  --schema-file /etc/schema.json \
+  --coordinator \
+  --no-backup \
+  --no-scaling
 ```
 
-This command sets up [multiple storage instances](https://scalardb.scalar-labs.com/docs/latest/multi-storage-transactions/) that consist of DynamoDB, PostgreSQL, and Cassandra. Then, the command creates namespaces for `dynamons`, `postgresns`, and `cassandrans` that are mapped to those storages, creates tables for `dynamons.customer`, `postgresns.orders`, and `cassandrans.lineitem` by using [ScalarDB SQL](https://scalardb.scalar-labs.com/docs/latest/scalardb-sql/getting-started-with-sql/), and loads sample data into the tables.
+This command sets up [multiple storage instances](https://scalardb.scalar-labs.com/docs/latest/multi-storage-transactions/) that consist of DynamoDB, PostgreSQL, and Cassandra. Then, the command creates namespaces for `dynamons`, `postgresns`, and `cassandrans` that are mapped to those storages, creates tables for `dynamons.customer`, `postgresns.orders`, and `cassandrans.lineitem` by using [ScalarDB Schema Loader](https://scalardb.scalar-labs.com/docs/latest/schema-loader/).
 
 ![Multi-storage overview](./images/multi-storage-overview.png)
+
+You can load sample data into the created tables by running the following command.
+
+```console
+$ docker compose run --rm sample-data-loader
+```
 
 ## Import the schemas from ScalarDB into PostgreSQL
 


### PR DESCRIPTION
## Description

This PR revises the Getting Started document so that it doesn't depend on ScalarDB SQL, which is not a part of ScalarDB Community Edition.

## Related issues and/or PRs

- https://scalar-labs.atlassian.net/browse/DLT-14713
- https://github.com/scalar-labs/scalardb-samples/pull/56

## Changes made

- Revises the Getting Started document to load sample data using a Java application instead of ScalarDB SQL

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A