### PR TITLE
DLT-14910 Fix scalardb_fdw issues incorrectly returning 0 results for particular queries

### DIFF
--- a/scalardb_fdw/Makefile
+++ b/scalardb_fdw/Makefile
@@ -33,7 +33,7 @@ OS = $(shell uname | tr '[:upper:]' '[:lower:]')
 
 PG_CPPFLAGS = -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(OS) -D'SCALARDB_JAR_PATH=$(scalardb_jar_path)'
 
-libjvm_path = $(shell find -L $(JAVA_HOME) -name libjvm\.*)
+libjvm_path = $(word 1, $(shell find -L $(JAVA_HOME) -name libjvm\.*))
 
 SHLIB_LINK+=-L$(dir $(libjvm_path)) -ljvm
 

--- a/scalardb_fdw/expected/scalardb_fdw.pg15.out
+++ b/scalardb_fdw/expected/scalardb_fdw.pg15.out
@@ -895,3 +895,39 @@ explain verbose select * from postgresns_test where p_pk = 1 order by p_ck1 ASC,
          ScalarDB Scan Attribute: ("p_pk" "p_ck1" "p_ck2" "p_boolean_col" "p_int_col" "p_bigint_col" "p_float_col" "p_double_col" "p_text_col" "p_blob_col")
 (10 rows)
 
+-- Columns that are required to evaluate WHERE clause locally at PostgreSQL side must be returned from the remote server
+-- - ForeignScan on cassandrans_test must return c_boolean_col
+explain verbose select p_pk from postgresns_test inner join cassandrans_test on p_pk = c_pk where c_boolean_col;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Merge Join  (cost=303.89..632.27 rows=21404 width=4)
+   Output: postgresns_test.p_pk
+   Merge Cond: (cassandrans_test.c_pk = postgresns_test.p_pk)
+   ->  Sort  (cost=106.17..109.83 rows=1463 width=4)
+         Output: cassandrans_test.c_pk
+         Sort Key: cassandrans_test.c_pk
+         ->  Foreign Scan on public.cassandrans_test  (cost=0.00..29.26 rows=1463 width=4)
+               Output: cassandrans_test.c_pk
+               Filter: cassandrans_test.c_boolean_col
+               ScalarDB Namespace: cassandrans
+               ScalarDB Table: test
+               ScalarDB Scan Type: all
+               ScalarDB Scan Attribute: ("c_pk" "c_boolean_col")
+   ->  Sort  (cost=197.72..205.04 rows=2926 width=4)
+         Output: postgresns_test.p_pk
+         Sort Key: postgresns_test.p_pk
+         ->  Foreign Scan on public.postgresns_test  (cost=0.00..29.26 rows=2926 width=4)
+               Output: postgresns_test.p_pk
+               ScalarDB Namespace: postgresns
+               ScalarDB Table: test
+               ScalarDB Scan Type: all
+               ScalarDB Scan Attribute: ("p_pk")
+(22 rows)
+
+-- - The query must return 1 row
+select p_pk from postgresns_test inner join cassandrans_test on p_pk = c_pk where c_boolean_col;
+ p_pk 
+------
+    1
+(1 row)
+

--- a/scalardb_fdw/sql/scalardb_fdw.pg15.sql
+++ b/scalardb_fdw/sql/scalardb_fdw.pg15.sql
@@ -247,3 +247,9 @@ explain verbose select * from postgresns_test where p_pk = 1 order by p_ck1 DESC
 explain verbose select * from postgresns_test where p_pk = 1 order by p_ck1 ASC, p_ck2 ASC; -- OK
 explain verbose select * from postgresns_test where p_pk = 1 order by p_ck1 DESC, p_ck2 DESC; -- OK
 explain verbose select * from postgresns_test where p_pk = 1 order by p_ck1 ASC, p_ck2 DESC; -- NG
+
+-- Columns that are required to evaluate WHERE clause locally at PostgreSQL side must be returned from the remote server
+-- - ForeignScan on cassandrans_test must return c_boolean_col
+explain verbose select p_pk from postgresns_test inner join cassandrans_test on p_pk = c_pk where c_boolean_col;
+-- - The query must return 1 row
+select p_pk from postgresns_test inner join cassandrans_test on p_pk = c_pk where c_boolean_col;


### PR DESCRIPTION
## Description

ScalarDB Analytics with PostgreSQL returns empty results wrongly for particular queries, including the query of [the sample query in the official document](https://scalardb.scalar-labs.com/docs/latest/scalardb-samples/scalardb-analytics-postgresql-sample/README/#run-analytical-queries).

This PR fixes this issue.

## Related issues and/or PRs

https://scalar-labs.atlassian.net/browse/DLT-14910

## Changes made

The `attrs_used`, which is a list of attributes that we ask the foreign query to return, is now retrieved after determining `local_conds`, which is a list of conditions evaluated locally on the PostgreSQL side.

The issue is caused by the column-pruning feature. The expected behavior is that the ForeignScan returns the columns that are included in the target list or required to evaluate expressions in join, where, order by, etc. However, since the `attrs_used` was calculated before the `local_conds` was initialized, the query results became an empty wrongly.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This issue affects #48 because it also bumps up the `scalardb_fdw` version to 3.10, which introduced the column-pruning feature. 

Thank you @kota2and3kan and @josh-wong for reporting the issue!

## Release notes

Fixes wrong behavior in column pruning in `scalardb_fdw`
