### PR TITLE
Set rpath to enable building `scalardb_fdw` on MacOS

### DIFF
--- a/scalardb_fdw/Makefile
+++ b/scalardb_fdw/Makefile
@@ -34,8 +34,13 @@ OS = $(shell uname | tr '[:upper:]' '[:lower:]')
 PG_CPPFLAGS = -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(OS) -D'SCALARDB_JAR_PATH=$(scalardb_jar_path)'
 
 libjvm_path = $(word 1, $(shell find -L $(JAVA_HOME) -name libjvm\.*))
+libjvm_dir = $(dir $(libjvm_path))
 
-SHLIB_LINK+=-L$(dir $(libjvm_path)) -ljvm
+ifeq ($(OS),darwin)
+	SHLIB_LINK+=-L$(libjvm_dir) -ljvm -rpath $(libjvm_dir)
+else
+	SHLIB_LINK+=-L$(libjvm_dir) -ljvm
+endif
 
 EXTRA_CLEAN = build
 


### PR DESCRIPTION
## Description

This PR enables us to build `scalardb_fdw` on Mac more handy by setting `rpath` when building it.

## Related issues and/or PRs

This PR is marked as a draft because it is based on #49. After #49 is merged, I will change the base branch to `main` and make this PR ready for merge.

## Changes made

* Set `rpath` to the path to the directory containing `libjvm.dylib` when being built on Mac.
  * The reason why this is required is described in the `Additional notes` section.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

* Since `libjvm` is a dynamic library, it must be found when PostgreSQL loads `scalardb_fdw`
* `rpath` is a library search path, which is similar to `LD_LIBRARY_PATH` for Linux but is embedded and resolved when building binary.
  * You can see what path is embedded in each binary with `otool -l`. For example:
```console
❯ otool -L /opt/homebrew/lib/postgresql@15/scalardb_fdw.so
/opt/homebrew/lib/postgresql@15/scalardb_fdw.so:
        @rpath/libjvm.dylib (compatibility version 1.0.0, current version 1.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1336.61.1)
```
 * Previously, if `rpath` is not specified, when the library is loaded, the loader (i..e. `dyld` on Mac) also searches it in the default paths including `/usr/local/lib`.
  * That's why `scalardb_works` works if users put the `libjvm.dylib` under `/usr/local/lib`, as described in the `README.md`
* However, this behavior seems to be changed in some update (maybe from Sonoma?) so that it doesn't see `/usr/local/lib` anymore unless it is specified as `rpath` explicitly.

## Release notes

N/A