### PR TITLE
Bump scalardb version to 3.11.0

### DIFF
--- a/scalardb_fdw/Makefile
+++ b/scalardb_fdw/Makefile
@@ -19,7 +19,7 @@ OBJS = scalardb_fdw.o option.o scalardb.o condition.o column_metadata.o pgport.o
 EXTENSION = scalardb_fdw
 DATA = scalardb_fdw--1.0.sql
 
-scalardb_version = 3.10.1
+scalardb_version = 3.11.0
 
 scalardb_jar = scalardb-$(scalardb_version)-all.jar
 scalardb_jar_built = scalardb-utils/build/libs/$(scalardb_jar)

--- a/scalardb_fdw/build.gradle
+++ b/scalardb_fdw/build.gradle
@@ -30,7 +30,7 @@ subprojects {
     apply plugin: 'com.diffplug.spotless'
 
     ext {
-        scalarDbVersion = '3.10.1'
+        scalarDbVersion = '3.11.0'
         slf4jVersion = '1.7.36'
         shadowPluginVersion = '7.1.2'
         googleJavaFormatVersion = '1.7'

--- a/schema-importer/app/build.gradle.kts
+++ b/schema-importer/app/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
 }
 
 dependencies {
-    implementation("com.scalar-labs:scalardb:3.10.1")
+    implementation("com.scalar-labs:scalardb:3.11.0")
     implementation("com.github.ajalt.clikt:clikt:3.5.2")
     implementation("org.postgresql:postgresql:42.5.1")
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")


### PR DESCRIPTION
## Description

This PR bumps up the version of the ScalarDB library.

## Related issues and/or PRs

None

## Changes made

* This PR bumps the ScalarDB version in two `build.gradle`, one for `scalardb_fdw`, one for `schema-importer`.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

N/A
