### PR TITLE
DLT-15046 Support SQLite in Schema Importer

### DIFF
--- a/schema-importer/app/src/main/kotlin/com/scalar/db/analytics/postgresql/schemaimporter/CreateServers.kt
+++ b/schema-importer/app/src/main/kotlin/com/scalar/db/analytics/postgresql/schemaimporter/CreateServers.kt
@@ -80,6 +80,7 @@ class CreateServers(
                 url.startsWith("jdbc:mysql:") -> "com.mysql.jdbc.Driver"
                 url.startsWith("jdbc:oracle:") -> "oracle.jdbc.OracleDriver"
                 url.startsWith("jdbc:sqlserver:") -> "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+                url.startsWith("jdbc:sqlite:") -> "org.sqlite.JDBC"
                 else -> throw IllegalArgumentException("Unsupported JDBC URL: $url")
             }
 


### PR DESCRIPTION
## Description

This PR adds support for SQLite in Schema Importer

## Related issues and/or PRs

@feeblefakie pointed out that ScalarDB supports SQLite in the PR of ScalarDB Analytics with Spark in [this comment[(https://github.com/scalar-labs/scalardb-analytics-spark/pull/5#discussion_r1477535283). ScalarDB Analytics with PostgreSQL should support SQLite as well.

## Changes made

* Add support for SQLite

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None

## Release notes

* Add support for SQLite