### PR TITLE
Add notice about the relocation of docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,9 @@
+> [!CAUTION]
+> 
+> This documentation has been moved to the centralized ScalarDB documentation repository, [docs-internal-scalardb](https://github.com/scalar-labs/docs-internal-scalardb). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDB documentation, visit [ScalarDB Documentation](https://scalardb.scalar-labs.com/docs/).
+
 # Getting Started with ScalarDB Analytics with PostgreSQL
 
 This document explains how to get started with ScalarDB Analytics with PostgreSQL. We assume that you have already installed ScalarDB Analytics with PostgreSQL and that all required services are running. If you don't have such an environment, please follow the instructions in [How to Install ScalarDB Analytics with PostgreSQL in Your Local Environment by Using Docker](./installation.md). Because ScalarDB Analytics with PostgreSQL executes queries via PostgreSQL, we also assume that you already have a `psql` client or another PostgreSQL client to send queries to PostgreSQL.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,3 +1,9 @@
+> [!CAUTION]
+> 
+> This documentation has been moved to the centralized ScalarDB documentation repository, [docs-internal-scalardb](https://github.com/scalar-labs/docs-internal-scalardb). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDB documentation, visit [ScalarDB Documentation](https://scalardb.scalar-labs.com/docs/).
+
 # How to Install ScalarDB Analytics with PostgreSQL in Your Local Environment by Using Docker
 
 This document explains how to set up a local environment that runs ScalarDB Analytics with PostgreSQL using the multi-storage back-end of Cassandra, PostgreSQL, and DynamoDB local server using [Docker Compose](https://docs.docker.com/compose/).

--- a/scalardb_fdw/README.md
+++ b/scalardb_fdw/README.md
@@ -1,3 +1,9 @@
+> [!CAUTION]
+> 
+> This documentation has been moved to the centralized ScalarDB documentation repository, [docs-internal-scalardb](https://github.com/scalar-labs/docs-internal-scalardb). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDB documentation, visit [ScalarDB Documentation](https://scalardb.scalar-labs.com/docs/).
+
 # ScalarDB FDW
 
 ScalarDB FDW is a PostgreSQL extension that implements a foreign data wrapper (FDW) for [ScalarDB](https://www.scalar-labs.com/scalardb/).

--- a/schema-importer/README.md
+++ b/schema-importer/README.md
@@ -1,3 +1,9 @@
+> [!CAUTION]
+> 
+> This documentation has been moved to the centralized ScalarDB documentation repository, [docs-internal-scalardb](https://github.com/scalar-labs/docs-internal-scalardb). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDB documentation, visit [ScalarDB Documentation](https://scalardb.scalar-labs.com/docs/).
+
 # Schema Importer
 
 Schema Importer is a CLI tool for automatically configuring PostgreSQL. By using this tool, your PostgreSQL database can have identical database objects, such as namespaces and tables, as your ScalarDB instance.


### PR DESCRIPTION
## Description

This PR adds a cautionary notice to the top of docs in the `docs` folder. Since those docs should now be updated in the [scalar-labs/docs-internal-scalardb](https://github.com/scalar-labs/docs-internal-scalardb) repository, the cautionary notice that I've added here is to provide guidance for those who may not know where to update the docs.

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-internal-scalardb/pull/15

## Changes made

- Added a cautionary notice to the top of each doc in the `docs` folder, stating that the doc should be updated in the [scalar-labs/docs-internal-scalardb](https://github.com/scalar-labs/docs-internal-scalardb) repository.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The `docs` folder in this repository can be deleted after we have moved all product docs to the [scalar-labs/docs-internal](https://github.com/scalar-labs/docs-internal) repository and confirmed that the migration was a success.

## Release notes

N/A