### PR TITLE
Remove relative link to docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ScalarDB Analytics with PostgreSQL expands the capabilities of [ScalarDB](https://www.scalar-labs.com/scalardb/) to support various queries, including joins and aggregations, and enables users to run advanced processing, such as ad-hoc analysis.
 
-ScalarDB Analytics with PostgreSQL, as the name suggests, uses PostgreSQL to execute queries on the data that ScalarDB manages, enabling users to perform various queries that PostgreSQL supports. For details, see the [docs](./docs).
+ScalarDB Analytics with PostgreSQL, as the name suggests, uses PostgreSQL to execute queries on the data that ScalarDB manages, enabling users to perform various queries that PostgreSQL supports.
 
 ## Online documentation
 


### PR DESCRIPTION
## Description

This PR removes a relative link to the docs on GitHub since a list of docs that point to the docs on the docs site exists in the `Online documentation` section of the README.

## Related issues and/or PRs

N/A

## Changes made

- Removed a relative link to the docs on GitHub.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
